### PR TITLE
Upgrade symfony/yaml and add phpunit as a dev dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,9 @@
     "require": {
         "php": ">=5.3.3",
         "heartsentwined/arg-validator": "1.*",
-        "symfony/yaml": "2.0.*"
+        "symfony/yaml": "*"
+    },
+    "require-dev": {
+        "phpunit/phpunit": "*"
     }
 }


### PR DESCRIPTION
In order to use phpspec with your heartsentwined/zf-cron module, we need to up the symfony/yaml version.

Tests are OK.

If you can review it and create a new tag :).
